### PR TITLE
Use pure Rust protobuf_codegen to avoid protoc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "beancount-parser-lima"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "beancount-parser-lima-python"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "beancount-parser-lima",
  "lazy_format",

--- a/beancount-parser-lima-python/Cargo.toml
+++ b/beancount-parser-lima-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beancount-parser-lima-python"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Python bindings for beancount-parser-lima"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-beancount-parser-lima = { version = "0.7.0", path = "../beancount-parser-lima" }
+beancount-parser-lima = { version = "0.7.1", path = "../beancount-parser-lima" }
 pyo3 = { version = "0.23.4", features = [
   "extension-module",
   "rust_decimal",

--- a/beancount-parser-lima-python/docker/Dockerfile
+++ b/beancount-parser-lima-python/docker/Dockerfile
@@ -1,8 +1,0 @@
-FROM ghcr.io/pyo3/maturin
-
-ARG PROTOC_VERSION=25.6
-
-RUN \
-    curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
-    unzip -d /usr/local protoc.zip && \
-    rm -f protoc.zip

--- a/beancount-parser-lima-python/pyproject.toml
+++ b/beancount-parser-lima-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "beancount-parser-lima"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python bindings for beancount-parser-lima"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/beancount-parser-lima/Cargo.toml
+++ b/beancount-parser-lima/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beancount-parser-lima"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A zero-copy parser for Beancount"

--- a/beancount-parser-lima/build.rs
+++ b/beancount-parser-lima/build.rs
@@ -5,7 +5,7 @@ fn autogen_beancount_proto() {
     let proto_dir = cargo_manifest_dir.join("protobuf");
 
     protobuf_codegen::Codegen::new()
-        .protoc()
+        .pure()
         .include(proto_dir.as_path())
         .inputs(
             [

--- a/flake.nix
+++ b/flake.nix
@@ -42,9 +42,6 @@
               rust-bin.stable.latest.default
               rustfmt
 
-              # for protoc, used for parser test schema
-              protobuf
-
               # for Python bindings
               maturin
               (python3.withPackages (ps: with ps; [ pip ]))

--- a/justfile
+++ b/justfile
@@ -4,13 +4,10 @@ build:
 test:
     cargo test
 
-build-image := "maturin-protoc:1"
-[working-directory: 'beancount-parser-lima-python/docker']
-build-container:
-    docker build . -t {{build-image}}
+build-image := "ghcr.io/pyo3/maturin"
 
 [working-directory: 'beancount-parser-lima-python']
-build-python-wheel: build-container
+build-python-wheel:
     docker run --rm -v $(pwd)/..:/io -w /io/beancount-parser-lima-python {{build-image}} build --release
 
 upload-testpypi:


### PR DESCRIPTION
Otherwise any use of this crate requires protoc to be installed,
which is pretty tragic, as it's only needed for running the tests.

(There doesn't seem to be a way to run build scripts just for tests.)

Fixes #19
